### PR TITLE
pages: not showing content column fix

### DIFF
--- a/invenio_pages/admin.py
+++ b/invenio_pages/admin.py
@@ -28,6 +28,7 @@ from invenio_pages.models import Page
 
 from jinja2 import TemplateNotFound
 
+from wtforms import TextAreaField
 from wtforms.validators import ValidationError
 
 
@@ -62,6 +63,7 @@ class PagesAdmin(ModelView):
         template_name=dict(
             validators=[template_exists]
         ))
+    form_overrides = dict(content=TextAreaField)
 
     # FIXME if we want to prevent users from modifying the dates
     # form_widget_args = {


### PR DESCRIPTION
* FIX Overrides default wtforms field for content column in order to
  display it properly. (closes inveniosoftware/invenio#3311)

Signed-off-by: Adrian Pawel Baran <adrian.pawel.baran@cern.ch>