### PR TITLE
global: fix import of invenio_upgrader

### DIFF
--- a/invenio_pages/upgrades/pages_2014_04_22_new_model.py
+++ b/invenio_pages/upgrades/pages_2014_04_22_new_model.py
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 from sqlalchemy.dialects import mysql
 
 depends_on = []

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-upgrader>=0.1.0',
     'Invenio>=2.0.3',
 ]
 


### PR DESCRIPTION
* FIX Fixes import of invenio_upgrader in the past upgrade recipes
  following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>