### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_pages/admin.py
+++ b/invenio_pages/admin.py
@@ -24,7 +24,7 @@ import os
 
 from flask import current_app
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 from invenio.ext.admin.views import ModelView
 from invenio.ext.sqlalchemy import db

--- a/invenio_pages/views.py
+++ b/invenio_pages/views.py
@@ -25,8 +25,8 @@ import six
 from flask import Blueprint, current_app, render_template, request
 from flask.ctx import after_this_request
 
-from invenio.base.globals import cfg
-from invenio.base.signals import before_handle_user_exception
+from invenio_base.globals import cfg
+from invenio_base.signals import before_handle_user_exception
 from invenio.ext.sqlalchemy import db
 from invenio_pages.models import Page
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -28,4 +28,5 @@
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
     'invenio-upgrader>=0.1.0',
     'Invenio>=2.0.3',
 ]
@@ -49,6 +50,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -22,7 +22,7 @@
 from flask import url_for
 
 from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.ext.sqlalchemy import db
 
 Page = lazy_import('invenio_pages.models:Page')


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>