### PR TITLE
installation: invenio-db[versioning]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,13 +49,13 @@ extras_require = {
         'Sphinx>=1.3',
     ],
     'mysql': [
-        'invenio-db[mysql]>=1.0.0a7',
+        'invenio-db[mysql,versioning]>=1.0.0a8',
     ],
     'postgresql': [
-        'invenio-db[postgresql]>=1.0.0a7',
+        'invenio-db[postgresql,versioning]>=1.0.0a8',
     ],
     'sqlite': [
-        'invenio-db>=1.0.0a7',
+        'invenio-db[versioning]>=1.0.0a8',
     ],
     'tests': tests_require,
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,8 @@
 
 from __future__ import absolute_import, print_function
 
+from invenio_db import db
+
 from invenio_pages import InvenioPages, Page
 from invenio_pages.views import blueprint
 
@@ -38,3 +40,20 @@ def test_page_repr(pages_fixture):
     with app.app_context():
         dog_page = Page.get_by_url('/dogs/shiba')
         assert dog_page.__repr__() == 'URL: /dogs/shiba, title: Page for doge!'
+
+
+def test_page_versions(pages_fixture):
+    app = pages_fixture
+    InvenioPages(app)
+    app.register_blueprint(blueprint)
+
+    with app.app_context():
+        dog_page = Page.get_by_url('/dogs')
+        dog_page.title = 'Just a dog!'
+        db.session.commit()
+
+    with app.app_context():
+        dog_page = Page.get_by_url('/dogs')
+        assert 'Just a dog!' == dog_page.title
+        assert 2 == dog_page.versions.count()
+        assert 'Page for Dogs!' == dog_page.versions[0].title


### PR DESCRIPTION
* Adds tests for versioning support.  (closes #17)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
- [x] depends on inveniosoftware/invenio-db#26
- [x] restart travis after releasing invenio-db-v1.0.0a8