### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -30,8 +30,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Pages.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-pages
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_pages/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_pages/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-pages 0.1.3.dev20151007\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-10-07 14:52+0200\n"
 "PO-Revision-Date: 2015-10-07 14:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_pages/translations/es/LC_MESSAGES/messages.po
+++ b/invenio_pages/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-pages 0.1.3.dev20151007\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-10-07 14:52+0200\n"
 "PO-Revision-Date: 2015-10-07 14:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_pages/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio_pages/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-pages 0.1.3.dev20151007\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-10-07 14:52+0200\n"
 "PO-Revision-Date: 2015-10-07 14:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_pages/translations/it/LC_MESSAGES/messages.po
+++ b/invenio_pages/translations/it/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-pages 0.1.3.dev20151007\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-10-07 14:52+0200\n"
 "PO-Revision-Date: 2015-10-07 14:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_pages/translations/messages.pot
+++ b/invenio_pages/translations/messages.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-pages 1.0.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-12-15 19:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_pages/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_pages/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
     keywords='invenio pages',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-pages',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>