### PR TITLE
fix: SADeprecationWarning

### DIFF
--- a/invenio_pages/records/models.py
+++ b/invenio_pages/records/models.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2025 CERN.
 # Copyright (C) 2025      University of Münster.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -104,8 +105,12 @@ class PageModel(db.Model, Timestamp):
         :param filters: The search filters.
         :returns: A list of the :class:`invenio_pages.records.models.PageModel` instance.
         """
+        # if filters == [] -> True
+        # if filters != [] -> False
+        default_element = not bool(len(filters))
+
         pages = (
-            PageModel.query.filter(or_(*filters))
+            PageModel.query.filter(or_(default_element, *filters))
             .order_by(
                 search_params["sort_direction"](text(",".join(search_params["sort"])))
             )

--- a/invenio_pages/records/models.py
+++ b/invenio_pages/records/models.py
@@ -12,10 +12,8 @@
 
 from flask import current_app
 from invenio_db import db
-from sqlalchemy import or_
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import validates
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import text
 from sqlalchemy_utils.models import Timestamp
 
@@ -105,12 +103,8 @@ class PageModel(db.Model, Timestamp):
         :param filters: The search filters.
         :returns: A list of the :class:`invenio_pages.records.models.PageModel` instance.
         """
-        # if filters == [] -> True
-        # if filters != [] -> False
-        default_element = not bool(len(filters))
-
         pages = (
-            PageModel.query.filter(or_(default_element, *filters))
+            self.query.filter(*filters)
             .order_by(
                 search_params["sort_direction"](text(",".join(search_params["sort"])))
             )

--- a/invenio_pages/records/models.py
+++ b/invenio_pages/records/models.py
@@ -53,11 +53,11 @@ class PageModel(db.Model, Timestamp):
     )
 
     @classmethod
-    def create(self, data):
+    def create(cls, data):
         """Create a new page."""
         try:
             with db.session.begin_nested():
-                obj = PageModel(
+                obj = cls(
                     url=data["url"],
                     title=data.get("title", ""),
                     content=data.get("content", ""),
@@ -72,31 +72,31 @@ class PageModel(db.Model, Timestamp):
             raise PageNotCreatedError(data["url"])
 
     @classmethod
-    def get_by_url(self, url, lang="en"):
+    def get_by_url(cls, url, lang="en"):
         """Get a page by URL.
 
         :param url: The page URL.
         :returns: A :class:`invenio_pages.records.models.PageModel` instance.
         """
         try:
-            return self.query.filter_by(url=url, lang=lang).one()
+            return cls.query.filter_by(url=url, lang=lang).one()
         except NoResultFound:
             raise PageNotFoundError(url)
 
     @classmethod
-    def get(self, id):
+    def get(cls, id):
         """Get a page by ID.
 
         :param id: The page ID.
         :returns: A :class:`invenio_pages.records.models.PageModel` instance.
         """
         try:
-            return self.query.filter_by(id=id).one()
+            return cls.query.filter_by(id=id).one()
         except NoResultFound:
             raise PageNotFoundError(id)
 
     @classmethod
-    def search(self, search_params, filters):
+    def search(cls, search_params, filters):
         """Get pages according to param filters.
 
         :param search_params: The maximum resources to retreive.
@@ -104,7 +104,7 @@ class PageModel(db.Model, Timestamp):
         :returns: A list of the :class:`invenio_pages.records.models.PageModel` instance.
         """
         pages = (
-            self.query.filter(*filters)
+            cls.query.filter(*filters)
             .order_by(
                 search_params["sort_direction"](text(",".join(search_params["sort"])))
             )
@@ -117,21 +117,21 @@ class PageModel(db.Model, Timestamp):
         return pages
 
     @classmethod
-    def update(self, data, id):
+    def update(cls, data, id):
         """Update an existing page."""
         with db.session.begin_nested():
-            self.query.filter_by(id=id).update(data)
+            cls.query.filter_by(id=id).update(data)
 
     @classmethod
-    def delete(self, page):
+    def delete(cls, page):
         """Delete page by its id."""
         with db.session.begin_nested():
             db.session.delete(page)
 
     @classmethod
-    def delete_all(self):
+    def delete_all(cls):
         """Delete all pages."""
-        self.query.delete()
+        cls.query.delete()
 
     @validates("template_name")
     def validate_template_name(self, key, value):


### PR DESCRIPTION
* SADeprecationWarning: Invoking or_() without arguments is deprecated,
  and will be disallowed in a future release.   For an empty or_()
  construct, use 'or_(false(), *args)' or 'or_(False, *args)'.
  BannerModel.query.filter(or_(*filters))

* sqlalchemy/sqlalchemy#5054
