### PR TITLE
fix(models): update timestamp on page edit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 Changes
 =======
 
+Version v9.0.1 (released 2026-06-01)
+
+- fix: page ``updated`` timestamp now reflects last edit, not creation date (#118)
+
 Version v9.0.0 (released 2026-05-29)
 
 - chore(setup): bump dependencies

--- a/invenio_pages/records/models.py
+++ b/invenio_pages/records/models.py
@@ -119,7 +119,7 @@ class PageModel(db.Model, db.Timestamp):
     def update(cls, data, id):
         """Update an existing page."""
         with db.session.begin_nested():
-            page = cls.query.filter_by(id=id).one()
+            page = cls.get(id)
             for key, value in data.items():
                 setattr(page, key, value)
 

--- a/invenio_pages/records/models.py
+++ b/invenio_pages/records/models.py
@@ -119,7 +119,9 @@ class PageModel(db.Model, db.Timestamp):
     def update(cls, data, id):
         """Update an existing page."""
         with db.session.begin_nested():
-            cls.query.filter_by(id=id).update(data)
+            page = cls.query.filter_by(id=id).one()
+            for key, value in data.items():
+                setattr(page, key, value)
 
     @classmethod
     def delete(cls, page):

--- a/tests/records/test_records.py
+++ b/tests/records/test_records.py
@@ -133,6 +133,27 @@ def test_update(module_scoped_pages_fixture, base_app):
     assert page.template_name == "invenio_pages/default.html"
 
 
+def test_update_timestamp(base_app, db):
+    data = {
+        "url": "/timestamp-test",
+        "title": "Before",
+        "content": "",
+        "lang": "en",
+        "description": "",
+        "template_name": "invenio_pages/default.html",
+    }
+    page = Page.create(data)
+    db.session.commit()
+    original_updated = page.updated
+
+    Page.update({"title": "After"}, page.id)
+    db.session.commit()
+
+    updated_page = Page.get(page.id)
+    assert updated_page.title == "After"
+    assert updated_page.updated > original_updated
+
+
 def test_delete_all(module_scoped_pages_fixture, base_app):
     Page.delete_all()
     pages = Page.search(map_search_params(PageServiceConfig.search, {}), [])


### PR DESCRIPTION
Query.update() bypasses ORM instance tracking, so db.Timestamp never fires. Fetch the instance first, then use setattr to trigger SQLAlchemy dirty-tracking and update the updated column correctly.

Closes #118

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
