### PR TITLE
fix: initialize jinja_env and app so dynamic pages render

### DIFF
--- a/invenio_pages/ext.py
+++ b/invenio_pages/ext.py
@@ -25,6 +25,7 @@ class InvenioPages(object):
 
         :param app: The Flask application. (Default: ``None``)
         """
+        self._jinja_env = None
         if app:
             self.init_app(app)
 
@@ -76,6 +77,7 @@ class InvenioPages(object):
         :returns: The :class:`invenio_pages.ext.InvenioPages` instance
             initialized.
         """
+        self.app = app
         self.init_config(app)
         self.init_services(app)
         self.init_resources(app)


### PR DESCRIPTION
## Summary

Static pages that use the dynamic template (`template_name: "invenio_pages/dynamic.html"`) currently fail to render — they raise `AttributeError` instead of returning the page. The sandboxed rendering feature is unusable out of the box.

The root cause is that `InvenioPages.jinja_env` (in `invenio_pages/ext.py`) reads two instance attributes that are **never initialized**.

## The issues

`dynamic.html` renders `{{ page.content|render_string|safe }}`. The `render_string` filter calls `current_app.extensions["invenio-pages"].render_template(...)`, which accesses the `jinja_env` property:

```python
@property
def jinja_env(self):
    if self._jinja_env is None:                                  # (1)
        self._jinja_env = SandboxedEnvironment(autoescape=True)
        self._jinja_env.globals["url_for"] = url_for
        for var in self.app.config["PAGES_WHITELIST_CONFIG_KEYS"]:  # (2)
            self._jinja_env.globals[var] = self.app.config.get(var)
    return self._jinja_env
```

1. **`self._jinja_env` is never initialized.** The property guards on `if self._jinja_env is None:`, but neither `__init__` nor `init_app` ever sets `self._jinja_env`, so the very first access raises `AttributeError: 'InvenioPages' object has no attribute '_jinja_env'`.

2. **`self.app` is never assigned.** The property reads `self.app.config[...]` to load the whitelisted config variables into the sandbox globals, but `self.app` is not set anywhere in the class, so it raises `AttributeError: 'InvenioPages' object has no attribute 'app'`.

Either one is enough to break every dynamic page; both are present.

## Steps to reproduce

1. Create a static page with `template_name = "invenio_pages/dynamic.html"` and some content (e.g. `Welcome to {{ THEME_SITENAME }}`).
2. Register/serve the page and request its URL.
3. The request 500s with `AttributeError` originating from `InvenioPages.jinja_env`, instead of rendering the (Jinja-evaluated) content.

## Fix

- Initialize `self._jinja_env = None` in `__init__` (before `init_app`, so the attribute always exists).
- Assign `self.app = app` in `init_app`.

```diff
     def __init__(self, app=None):
         """Extension initialization."""
+        self._jinja_env = None
         if app:
             self.init_app(app)

     def init_app(self, app):
         """Flask application initialization."""
+        self.app = app
         self.init_config(app)
         ...
```

After this, dynamic pages render and the whitelisted config variables (`PAGES_WHITELIST_CONFIG_KEYS`, e.g. `THEME_SITENAME`) resolve correctly inside the sandboxed environment.

## Notes

- Present on `master` and in the current release (reproduced on v10.0.0).
- Minimal, backwards-compatible change; no public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)