### PR TITLE
fix(tests): create `Page` fixtures one by one to space out creation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,40 +42,53 @@ def create_app(instance_path, entry_points):
 def pages_fixture(app, db):
     """Page fixtures.
 
+    The pages are added to the DB one by one to avoid pages having the same creation
+    timestamp, which could cause flaky tests with some tests.
+
     Scope: function
     """
-    pages = [
+    db.session.add(
         Page(
             url="/dogs",
             title="Page for Dogs!",
             content="Generic dog.",
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
         Page(
             url="/dogs/shiba",
             title="Page for doge!",
             content="so doge!",
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
         Page(
             url="/cows/",
             title="Page for Cows!",
             content="Generic cow.",
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
         Page(
             url="/htmldog",
             title="Page for modern dogs!",
             content="<h1>HTML aware dog.</h1>.\n" '<p class="test">paragraph<br /></p>',
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
-    ]
-    for page in pages:
-        db.session.add(page)
+        )
+    )
     db.session.commit()
 
 
@@ -83,41 +96,54 @@ def pages_fixture(app, db):
 def module_scoped_pages_fixture(app, database):
     """Page fixtures.
 
+    The pages are added to the DB one by one to avoid pages having the same creation
+    timestamp, which could cause flaky tests with some tests.
+
     Scope: module
     """
     db = database
-    pages = [
+    db.session.add(
         Page(
             url="/dogs",
             title="Page for Dogs!",
             content="Generic dog.",
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
         Page(
             url="/dogs/shiba",
             title="Page for doge!",
             content="so doge!",
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
         Page(
             url="/cows/",
             title="Page for Cows!",
             content="Generic cow.",
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
         Page(
             url="/htmldog",
             title="Page for modern dogs!",
             content="<h1>HTML aware dog.</h1>.\n" '<p class="test">paragraph<br /></p>',
             lang="en",
             template_name="invenio_pages/default.html",
-        ),
-    ]
-    for page in pages:
-        db.session.add(page)
+        )
+    )
     db.session.commit()
 
 


### PR DESCRIPTION
Alternative to https://github.com/inveniosoftware/invenio-pages/pull/125

The above linked PR did not fix the flaky tests for me; perhaps due to the `Page` models still being initialized temporally too closely together in the list.
Instead, this PR here spaces out both the Python model initialization as well as their addition to the database.